### PR TITLE
Add Note utility node

### DIFF
--- a/nodes/utility/note.py
+++ b/nodes/utility/note.py
@@ -1,0 +1,29 @@
+from ..utils import get_params
+
+NODE_TYPE = 'utility/note'
+NODE_CATEGORY = 'Utility'
+
+
+def execute(node, inputs):
+    params = get_params(node)
+    return params.get('text', '')
+
+
+def get_spec():
+    return {
+        'type': NODE_TYPE,
+        'title': 'Note',
+        'category': 'utility',
+        'node_category': NODE_CATEGORY,
+        'inputs': [],
+        'outputs': [],
+        'widgets': [
+            {
+                'kind': 'textarea',
+                'name': 'Text',
+                'bind': 'text',
+            },
+        ],
+        'properties': {'text': ''},
+        'tooltip': 'Add notes to the graph',
+    }


### PR DESCRIPTION
## Summary
- introduce `utility/note` node for adding rich text notes to graphs

## Testing
- `python -m py_compile nodes/utility/note.py`

------
https://chatgpt.com/codex/tasks/task_e_686f779f29208330a65e43ca25daf0f4