### PR TITLE
Add rescale option for DARE TIES

### DIFF
--- a/nodes/merge_methods/dare_ties.py
+++ b/nodes/merge_methods/dare_ties.py
@@ -14,6 +14,7 @@ def execute(node, inputs):
     dropout = float(params.get('dropout', 0.0))
     density = 1.0 - dropout
     majority = params.get('majority_sign_method', 'total')
+    rescale = bool(params.get('rescale', True))
 
     base = inputs[0]
     others = inputs[1:]
@@ -27,9 +28,15 @@ def execute(node, inputs):
         models.append(inp['data'] if isinstance(inp, dict) else inp)
 
     weights = [1.0] * len(models)
-    merged = merge_state_dicts_with_base(base_data, models, weights, dare_ties,
-                                         density=density,
-                                         majority_sign_method=majority)
+    merged = merge_state_dicts_with_base(
+        base_data,
+        models,
+        weights,
+        dare_ties,
+        density=density,
+        majority_sign_method=majority,
+        rescale=rescale,
+    )
     return {'data': merged, 'format': fmt, 'dtype': dtype}
 
 
@@ -61,7 +68,17 @@ def get_spec():
                 'bind': 'majority_sign_method',
                 'options': {'values': ['total', 'frequency']}
             },
+            {
+                'kind': 'checkbox',
+                'name': 'Rescale After Pruning',
+                'bind': 'rescale'
+            },
         ],
-        'properties': {'dropout': 0.0, 'majority_sign_method': 'total'},
+        'properties': {
+            'dropout': 0.0,
+            'majority_sign_method': 'total',
+            'rescale': True,
+        },
         'tooltip': 'Merge full models relative to Base using the DARE TIES algorithm'
+                   '\nIf rescale is enabled, weights are divided by density after pruning.',
     }

--- a/utils/peft_utils.py
+++ b/utils/peft_utils.py
@@ -99,8 +99,14 @@ def dare_linear(task_tensors: List[torch.Tensor], weights: torch.Tensor, density
     return (pruned * weights).sum(dim=0)
 
 
-def dare_ties(task_tensors: List[torch.Tensor], weights: torch.Tensor, density: float, majority_sign_method: Literal["total", "frequency"] = "total") -> torch.Tensor:
-    pruned = [prune(t, density, method="random", rescale=True) for t in task_tensors]
+def dare_ties(
+    task_tensors: List[torch.Tensor],
+    weights: torch.Tensor,
+    density: float,
+    majority_sign_method: Literal["total", "frequency"] = "total",
+    rescale: bool = True,
+) -> torch.Tensor:
+    pruned = [prune(t, density, method="random", rescale=rescale) for t in task_tensors]
     pruned = torch.stack(pruned, dim=0)
     majority_sign_mask = calculate_majority_sign_mask(pruned, method=majority_sign_method)
     weights = reshape_weight_task_tensors(pruned, weights)


### PR DESCRIPTION
## Summary
- extend `dare_ties` algorithm with optional rescale parameter
- expose rescale toggle in DARE TIES full merge node

## Testing
- `python -m py_compile nodes/merge_methods/dare_ties.py utils/peft_utils.py`
- `python -m py_compile nodes/peft_merging/dare_ties.py`

------
https://chatgpt.com/codex/tasks/task_e_6882e1ee473c83308e5c6e33eb3eff5f